### PR TITLE
Revert "Bump `xo` to v0.17.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,11 @@
   },
   "devDependencies": {
     "ava": "^0.17.0",
-    "eslint": "^3.7.1",
     "eslint-ava-rule-tester": "^0.1.1",
     "inject-in-tag": "^1.1.1",
     "nyc": "^6.4.4",
     "pify": "^2.3.0",
-    "xo": "^0.17.0"
+    "xo": "^0.15.1"
   },
   "peerDependencies": {
     "eslint": ">=3"


### PR DESCRIPTION
Fixes #33. This reverts commit 068269609df95ce2e4d841c7d05c4a609a3ee05f.