### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/rules/no-arguments.js
+++ b/rules/no-arguments.js
@@ -36,7 +36,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `arguments`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-arguments.md'
     }
   }
 };

--- a/rules/no-class.js
+++ b/rules/no-class.js
@@ -16,7 +16,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `class`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-class.md'
     }
   }
 };

--- a/rules/no-delete.js
+++ b/rules/no-delete.js
@@ -18,7 +18,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `delete`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-delete.md'
     }
   }
 };

--- a/rules/no-events.js
+++ b/rules/no-events.js
@@ -29,7 +29,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of the `events` module.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-events.md'
     }
   }
 };

--- a/rules/no-get-set.js
+++ b/rules/no-get-set.js
@@ -50,7 +50,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of getters and setters.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-get-set.md'
     }
   }
 };

--- a/rules/no-let.js
+++ b/rules/no-let.js
@@ -18,7 +18,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `let`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-let.md'
     }
   }
 };

--- a/rules/no-loops.js
+++ b/rules/no-loops.js
@@ -30,7 +30,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of loops.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-loops.md'
     }
   }
 };

--- a/rules/no-mutating-assign.js
+++ b/rules/no-mutating-assign.js
@@ -46,7 +46,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of [`Object.assign()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) with a variable as first argument.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-mutating-assign.md'
     }
   }
 };

--- a/rules/no-mutating-methods.js
+++ b/rules/no-mutating-methods.js
@@ -85,7 +85,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of mutating methods.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-mutating-methods.md'
     }
   }
 };

--- a/rules/no-mutation.js
+++ b/rules/no-mutation.js
@@ -124,7 +124,8 @@ module.exports = {
     schema,
     docs: {
       description: 'Forbid the use of mutating operators.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-mutation.md'
     }
   }
 };

--- a/rules/no-nil.js
+++ b/rules/no-nil.js
@@ -73,7 +73,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `null` and `undefined`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-nil.md'
     }
   }
 };

--- a/rules/no-proxy.js
+++ b/rules/no-proxy.js
@@ -18,7 +18,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `Proxy`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-proxy.md'
     }
   }
 };

--- a/rules/no-rest-parameters.js
+++ b/rules/no-rest-parameters.js
@@ -16,7 +16,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of rest parameters.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-rest-parameters.md'
     }
   }
 };

--- a/rules/no-this.js
+++ b/rules/no-this.js
@@ -16,7 +16,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `this`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-this.md'
     }
   }
 };

--- a/rules/no-throw.js
+++ b/rules/no-throw.js
@@ -16,7 +16,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the use of `throw`.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-throw.md'
     }
   }
 };

--- a/rules/no-unused-expression.js
+++ b/rules/no-unused-expression.js
@@ -55,7 +55,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Enforce that an expression gets used.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-unused-expression.md'
     }
   }
 };

--- a/rules/no-valueof-field.js
+++ b/rules/no-valueof-field.js
@@ -35,7 +35,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Forbid the creation of `valueOf` fields.',
-      recommended: 'error'
+      recommended: 'error',
+      url: 'https://github.com/jfmengels/eslint-plugin-fp/tree/master/docs/rules/no-valueof-field.md'
     }
   }
 };


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.