### PR TITLE
Allow Object.create(null) in no-mutating-assign

### DIFF
--- a/rules/no-mutating-assign.js
+++ b/rules/no-mutating-assign.js
@@ -19,13 +19,32 @@ const isObjectExpression = _.flow(
   _.includes(_, ['ObjectExpression', 'ArrayExpression'])
 );
 
+const isObjectCreateNull = _.matches({
+  type: 'CallExpression',
+  callee: {
+    type: 'MemberExpression',
+    object: {
+      type: 'Identifier',
+      name: 'Object'
+    },
+    property: {
+      type: 'Identifier',
+      name: 'create'
+    }
+  },
+  arguments: [{
+    type: 'Literal',
+    value: null
+  }]
+});
+
 const isFunctionExpression = _.flow(
   _.property('type'),
   _.includes(_, ['FunctionExpression', 'ArrowFunctionExpression'])
 );
 
 function isAllowedFirstArgument(arg) {
-  return isObjectExpression(arg) || isFunctionExpression(arg);
+  return isObjectExpression(arg) || isObjectCreateNull(arg) || isFunctionExpression(arg);
 }
 
 const create = function (context) {

--- a/test/no-mutating-assign.js
+++ b/test/no-mutating-assign.js
@@ -23,6 +23,8 @@ ruleTester.run('no-mutating-assign', rule, {
     'Object.foo(a, b);',
     'Object.assign({});',
     'Object.assign({}, b);',
+    'Object.assign(Object.create(null));',
+    'Object.assign(Object.create(null), b);',
     'Object.assign({}, b, c, d, e);',
     'Object.assign({foo: 1, bar: 2}, b);',
     'Object.assign([1, 2], b);',
@@ -57,6 +59,10 @@ ruleTester.run('no-mutating-assign', rule, {
     },
     {
       code: 'function fn() {}; Object.assign(fn, b);',
+      errors: [error]
+    },
+    {
+      code: 'Object.assign(Object.create)',
       errors: [error]
     }
   ]


### PR DESCRIPTION
Sometimes I see `Object.create(null)` as a first argument of `Object.assign()`, like in [eslint-plugin-jest's codebase](https://github.com/jest-community/eslint-plugin-jest/blob/18c97de214a69a61e742f48f678f6a8fb842adbc/rules/util.js#L83-L89). Thoughts on including it as an acceptable first argument in the `no-mutating-assign` rule?