### PR TITLE
Report for ClassExpression types in no-class rule

### DIFF
--- a/rules/no-class.js
+++ b/rules/no-class.js
@@ -1,13 +1,16 @@
 'use strict';
 
 const create = function (context) {
+  function report(node) {
+    context.report({
+      node,
+      message: 'Unallowed use of `class`. Use functions instead'
+    });
+  }
+
   return {
-    ClassDeclaration(node) {
-      context.report({
-        node,
-        message: 'Unallowed use of `class`. Use functions instead'
-      });
-    }
+    ClassDeclaration: report,
+    ClassExpression: report
   };
 };
 

--- a/test/no-class.js
+++ b/test/no-class.js
@@ -29,6 +29,18 @@ ruleTester.run('no-class', rule, {
         }
       }`,
       errors: [error]
+    },
+    {
+      code: 'export default class MyComponent extends React.Component {}',
+      errors: [error]
+    },
+    {
+      code: 'module.exports = class MyClass {}',
+      errors: [error]
+    },
+    {
+      code: 'const MyClass = class {}',
+      errors: [error]
     }
   ]
 });


### PR DESCRIPTION
Resolves #23 

`no-class` wasn't reporting for [ClassExpression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/class) node types. Here's an [AST explorer](https://astexplorer.net/#/gist/1beb6ff88b1ce5daa32b313bd41f9f66/a06627f30208c3386c24d7e1b5c30ff341c2e21b) if you're curious (helped me debug the issue).