### PR TITLE
Fix exceptions for literal property mutations

### DIFF
--- a/rules/no-mutation.js
+++ b/rules/no-mutation.js
@@ -42,18 +42,21 @@ function errorMessage(isCommonJs) {
   return baseMessage + (isCommonJs ? '. You may want to activate the `commonjs` option for this rule' : '');
 }
 
-function makeException(exception) {
+function makeExceptions(exception) {
   if (!exception.object && !exception.property) {
     return _.stubFalse;
   }
-  let query = {type: 'MemberExpression'};
-  if (exception.object) {
-    query = _.assign(query, {object: {type: 'Identifier', name: exception.object}});
-  }
+  let queries = [];
+  const query = {type: 'MemberExpression'};
   if (exception.property) {
-    query = _.assign(query, {property: {type: 'Identifier', name: exception.property}});
+    queries.push(_.assign(query, {property: {type: 'Identifier', name: exception.property}}));
+    queries.push(_.assign(query, {property: {type: 'Literal', value: exception.property}}));
   }
-  return _.matches(query);
+  if (exception.object) {
+    const objquery = {object: {type: 'Identifier', name: exception.object}};
+    queries = queries.length ? _.map(q => _.assign(q, objquery), queries) : [_.assign(query, objquery)];
+  }
+  return _.map(_.matches, queries);
 }
 
 function isExempted(exceptions, node) {
@@ -68,7 +71,7 @@ function isExempted(exceptions, node) {
 const create = function (context) {
   const options = context.options[0] || {};
   const acceptCommonJs = options.commonjs;
-  const exceptions = _.map(makeException, options.exceptions);
+  const exceptions = _.flatMap(makeExceptions, options.exceptions);
   if (options.allowThis) {
     exceptions.push(_.matches({type: 'MemberExpression', object: {type: 'ThisExpression'}}));
   }

--- a/test/no-mutation.js
+++ b/test/no-mutation.js
@@ -63,6 +63,12 @@ ruleTester.run('no-mutation', rule, {
       ]}]
     },
     {
+      code: 'foo["bar"] = {};',
+      options: [{exceptions: [
+        {property: 'bar'}
+      ]}]
+    },
+    {
       code: 'baz.propTypes = {};',
       options: [{exceptions: [
         {property: 'propTypes'}


### PR DESCRIPTION
The node for `foo['bar'] = {}` contains a literal type property. Since mutating
a property with literal or identifier notation makes no practical difference,
make exceptions for both type of expressions.