### PR TITLE
Fix loading rules when using Jest

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 'use strict';
 
-const reqAll = require('req-all');
+const fs = require('fs');
+const path = require('path');
 const createIndex = require('create-eslint-index');
 
-const rules = reqAll('rules', {camelize: false});
+const rules = {};
+for (const file of fs.readdirSync(`${__dirname}/rules`)) {
+  const ruleName = path.basename(file, path.extname(file));
+  rules[ruleName] = require(`./rules/${ruleName}`);
+}
 
 const externalRecommendedRules = {
   'no-var': 'error'

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   "dependencies": {
     "create-eslint-index": "^1.0.0",
     "eslint-ast-utils": "^1.0.0",
-    "lodash": "^4.13.1",
-    "req-all": "^0.1.0"
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
     "ava": "^0.17.0",


### PR DESCRIPTION
`req-all` relies on `require.extensions` under the hood, which gets modified by Jest, so loading rules in Jest (e.g. via ESLint Node.js API) doesn't work, it just results in an empty object.

Since we're loading our own files, we don't need some complicated logic to do this, we can roll our own. One less module to rely on.

Fixes #52.