### PR TITLE
Support MemberExpressions in no-mutating-methods allowedObjects

### DIFF
--- a/rules/no-mutating-methods.js
+++ b/rules/no-mutating-methods.js
@@ -45,6 +45,10 @@ const create = function (context) {
         return;
       }
 
+      if (node.callee.object.type === 'MemberExpression' && allowedObjects.indexOf(node.callee.object.property.name) !== -1) {
+        return;
+      }
+
       if (node.callee.object.name === 'Object') {
         if (mutatingObjectMethods.indexOf(node.callee.property.name) !== -1) {
           context.report({

--- a/test/no-mutating-methods.js
+++ b/test/no-mutating-methods.js
@@ -51,6 +51,12 @@ ruleTester.run('no-mutating-methods', rule, {
         allowedObjects: ['R']
       }]
     },
+    {
+      code: 'this.$router.push(a)',
+      options: [{
+        allowedObjects: ['$router']
+      }]
+    },
     'Object.keys(a)',
     'Object.values(a)'
   ],


### PR DESCRIPTION
In `no-mutating-methods`, the `allowedObjects` option currently only works on `Identifier` types, not `MemberExpression` types. This PR adds support for `MemberExpression` types.

For example, this currently reports an error:

```js
/* eslint fp/no-mutating-methods: ["error", {"allowedObjects": ["two"]}] */
one.two.push(a)
```

## Use Case

The standard way of navigating to a new route in [vue-router](https://router.vuejs.org/guide/essentials/navigation.html#router-push-location-oncomplete-onabort) is with `this.$router.push(...)`. Setting `"allowedObjects": ["$router"]` does not work as expected. There is no way to get `no-mutating-methods` to ignore this with the current implementation.

## Additional Nodes

This is a breaking change. I can add a different option to avoid breaking, but arguably the existing option should have always functioned this way.